### PR TITLE
fix(navbar): temporarily disable sticky by default as it causes issues

### DIFF
--- a/themes/base/src/components/mdx/navbar.js
+++ b/themes/base/src/components/mdx/navbar.js
@@ -21,7 +21,7 @@ import NavigationBar from '../navigation/bar'
 const NavBar = (props) => <NavigationBar {...props} />
 
 NavBar.defaultProps = {
-  sticky: true,
+  sticky: false,
   transparent: false,
 }
 

--- a/themes/base/src/components/navigation/bar.js
+++ b/themes/base/src/components/navigation/bar.js
@@ -127,7 +127,7 @@ const NavigationBar = ({
 
 NavigationBar.defaultProps = {
   transparent: false,
-  sticky: true,
+  sticky: false,
   background: 'root-background',
   textColor: 'root-text',
   transparentTextColor: 'white',


### PR DESCRIPTION
when changing route, the page breaks. 

The same issue exists in the playground, I was hoping to work around it by assuming its only an issue in the preview.. its not :(